### PR TITLE
Fix brackets error

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -303,7 +303,8 @@ variable "conditioned_roll" {
 variable "conditioned_roll_params" {
   type        = list(string)
   default     = null
-  description = "Customized List of conditioned roll params, it is valid only when conditioned_roll set to true"}
+  description = "Customized List of conditioned roll params, it is valid only when conditioned_roll set to true"
+}
 ##########################
 
 variable "data_integration_id" {


### PR DESCRIPTION
fixed a problem with brackets which caused the following error

```
╷
│ Error: Missing newline after argument
│ 
│   on .terraform/modules/ocean-aws-k8s/variables.tf line 306, in variable "conditioned_roll_params":
│  306:   description = "Customized List of conditioned roll params, it is valid only when conditioned_roll set to true"}
│ 
│ An argument definition must end with a newline.
╵

```

# Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code

