### PR TITLE
fixed drift issue for `scheduled_task` object when scheduling is not configured

### DIFF
--- a/ocean.tf
+++ b/ocean.tf
@@ -148,53 +148,56 @@ resource "spotinst_ocean_aws" "ocean" {
       respect_pdb                  = var.respect_pdb
     }
   }
-    # Scheduled Task Ami Auto Update and shut down hours##
-  scheduled_task {
-     dynamic "shutdown_hours" {
+
+  # Scheduled Task Ami Auto Update, Cluster Roll and shut down hours##
+  dynamic "scheduled_task" {
+    for_each = var.shutdown_hours != null || var.tasks != null ? [1] : []
+    content {
+      dynamic "shutdown_hours" {
         for_each = var.shutdown_hours != null ? [var.shutdown_hours] : []
         content {
           is_enabled   = shutdown_hours.value.is_enabled
           time_windows = shutdown_hours.value.time_windows
         }
       }
-     dynamic "tasks" {
+      dynamic "tasks" {
         for_each = var.tasks != null ? var.tasks : []
-          content {
-             cron_expression = tasks.value.cron_expression
-             is_enabled      = tasks.value.is_enabled
-             task_type       = tasks.value.task_type
-             parameters {
-                dynamic "ami_auto_update" {
-                   for_each = tasks.value.ami_auto_update
-                   content {
-                    apply_roll    = ami_auto_update.value.apply_roll
-                    minor_version = ami_auto_update.value.minor_version
-                    patch         = ami_auto_update.value.patch
-                    dynamic "ami_auto_update_cluster_roll" {
-                        for_each = ami_auto_update.value.ami_auto_update_cluster_roll
-                        content {
-                            batch_min_healthy_percentage = ami_auto_update_cluster_roll.value.batch_min_healthy_percentage
-                            batch_size_percentage        = ami_auto_update_cluster_roll.value.batch_size_percentage
-                            comment                      = ami_auto_update_cluster_roll.value.comment
-                            respect_pdb                  = ami_auto_update_cluster_roll.value.respect_pdb
-                        }
-                    }
-                   }
+        content {
+          cron_expression = tasks.value.cron_expression
+          is_enabled      = tasks.value.is_enabled
+          task_type       = tasks.value.task_type
+          parameters {
+            dynamic "ami_auto_update" {
+              for_each = tasks.value.ami_auto_update
+              content {
+                apply_roll    = ami_auto_update.value.apply_roll
+                minor_version = ami_auto_update.value.minor_version
+                patch         = ami_auto_update.value.patch
+                dynamic "ami_auto_update_cluster_roll" {
+                  for_each = ami_auto_update.value.ami_auto_update_cluster_roll
+                  content {
+                    batch_min_healthy_percentage = ami_auto_update_cluster_roll.value.batch_min_healthy_percentage
+                    batch_size_percentage        = ami_auto_update_cluster_roll.value.batch_size_percentage
+                    comment                      = ami_auto_update_cluster_roll.value.comment
+                    respect_pdb                  = ami_auto_update_cluster_roll.value.respect_pdb
+                  }
                 }
-                dynamic "parameters_cluster_roll" {
-                    for_each = tasks.value.parameters_cluster_roll
-                    content {
-                      batch_min_healthy_percentage = parameters_cluster_roll.value.batch_min_healthy_percentage
-                      batch_size_percentage        = parameters_cluster_roll.value.batch_size_percentage
-                      comment                      = parameters_cluster_roll.value.comment
-                      respect_pdb                  = parameters_cluster_roll.value.respect_pdb
-                    }
-                }
-             }
-
-         }
+              }
+            }
+            dynamic "parameters_cluster_roll" {
+              for_each = tasks.value.parameters_cluster_roll
+              content {
+                batch_min_healthy_percentage = parameters_cluster_roll.value.batch_min_healthy_percentage
+                batch_size_percentage        = parameters_cluster_roll.value.batch_size_percentage
+                comment                      = parameters_cluster_roll.value.comment
+                respect_pdb                  = parameters_cluster_roll.value.respect_pdb
+              }
+            }
+          }
+        }
+      }
     }
-}
+  }
 
   ## Block Device Mappings ##
   dynamic "block_device_mappings" {

--- a/variables.tf
+++ b/variables.tf
@@ -338,36 +338,35 @@ variable "shutdown_hours" {
     time_windows = list(string)
   })
   default     = null
-  description = "shutdown_hours object"
+  description = "Defines shutdown hours for the cluster."
 }
-###################
 
 # task scheduling #
 variable "tasks" {
   type = list(object({
-    is_enabled      = bool
-    cron_expression = string
-    task_type       = string
+    is_enabled      = optional(bool,null)
+    cron_expression = optional(string,null)
+    task_type       = optional(string,null)
     ami_auto_update = optional(set(object({
         apply_roll    = optional(bool,null)
         minor_version = optional(bool,null)
         patch         = optional(bool,null)
             ami_auto_update_cluster_roll = optional(set(object({
-                batch_min_healthy_percentage = optional(number,null)
-                batch_size_percentage = optional(number,null)
-                comment = optional(string,null)
-                respect_pdb = optional(bool,null)
+            batch_min_healthy_percentage = optional(number,null)
+            batch_size_percentage        = optional(number,null)
+            comment                      = optional(string,null)
+            respect_pdb                  = optional(bool,null)
             })), [])
     })), [])
     parameters_cluster_roll = optional(set(object({
         batch_min_healthy_percentage = optional(number,null)
-        batch_size_percentage = optional(number,null)
-        comment = optional(string,null)
-        respect_pdb = optional(bool,null)
+        batch_size_percentage        = optional(number,null)
+        comment                      = optional(string,null)
+        respect_pdb                  = optional(bool,null)
     })), [])
   }))
   default     = null
-  description = "task object"
+  description = "Defines scheduled tasks for the cluster."
 }
 ##################
 


### PR DESCRIPTION
fixed drift issue for `scheduled_task` object when scheduling is not configured

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
